### PR TITLE
Silence warnings

### DIFF
--- a/src/Cheats.c
+++ b/src/Cheats.c
@@ -928,24 +928,24 @@ int cheatsCheckKeys(u32 keys, u32 extended)
 		}
         break;
       case GSA_8_BIT_POINTER :
-        if ((CPUReadMemory(cheatsList[i].address)>=0x02000000) && (CPUReadMemory(cheatsList[i].address)<0x02040000) ||
-            (CPUReadMemory(cheatsList[i].address)>=0x03000000) && (CPUReadMemory(cheatsList[i].address)<0x03008000))
+        if ((CPUReadMemory(cheatsList[i].address)>=0x02000000 && CPUReadMemory(cheatsList[i].address)<0x02040000) ||
+            (CPUReadMemory(cheatsList[i].address)>=0x03000000 && CPUReadMemory(cheatsList[i].address)<0x03008000))
         {
           CPUWriteByte(CPUReadMemory(cheatsList[i].address)+((cheatsList[i].value & 0xFFFFFF00) >> 8),
                        cheatsList[i].value & 0xFF);
         }
         break;
       case GSA_16_BIT_POINTER :
-        if ((CPUReadMemory(cheatsList[i].address)>=0x02000000) && (CPUReadMemory(cheatsList[i].address)<0x02040000) ||
-            (CPUReadMemory(cheatsList[i].address)>=0x03000000) && (CPUReadMemory(cheatsList[i].address)<0x03008000))
+        if ((CPUReadMemory(cheatsList[i].address)>=0x02000000 && CPUReadMemory(cheatsList[i].address)<0x02040000) ||
+            (CPUReadMemory(cheatsList[i].address)>=0x03000000 && CPUReadMemory(cheatsList[i].address)<0x03008000))
         {
           CPUWriteHalfWord(CPUReadMemory(cheatsList[i].address)+((cheatsList[i].value & 0xFFFF0000) >> 15),
                        cheatsList[i].value & 0xFFFF);
         }
         break;
       case GSA_32_BIT_POINTER :
-        if ((CPUReadMemory(cheatsList[i].address)>=0x02000000) && (CPUReadMemory(cheatsList[i].address)<0x02040000) ||
-            (CPUReadMemory(cheatsList[i].address)>=0x03000000) && (CPUReadMemory(cheatsList[i].address)<0x03008000))
+        if ((CPUReadMemory(cheatsList[i].address)>=0x02000000 && CPUReadMemory(cheatsList[i].address)<0x02040000) ||
+            (CPUReadMemory(cheatsList[i].address)>=0x03000000 && CPUReadMemory(cheatsList[i].address)<0x03008000))
         {
           CPUWriteMemory(CPUReadMemory(cheatsList[i].address),
                        cheatsList[i].value);

--- a/src/Cheats.c
+++ b/src/Cheats.c
@@ -953,15 +953,15 @@ int cheatsCheckKeys(u32 keys, u32 extended)
         break;
       case GSA_8_BIT_ADD :
         CPUWriteByte(cheatsList[i].address,
-                    (cheatsList[i].value & 0xFF) + CPUReadMemory(cheatsList[i].address) & 0xFF);
+                    (cheatsList[i].value & 0xFF) + (CPUReadMemory(cheatsList[i].address) & 0xFF));
         break;
       case GSA_16_BIT_ADD :
         CPUWriteHalfWord(cheatsList[i].address,
-                        (cheatsList[i].value & 0xFFFF) + CPUReadMemory(cheatsList[i].address) & 0xFFFF);
+                        (cheatsList[i].value & 0xFFFF) + (CPUReadMemory(cheatsList[i].address) & 0xFFFF));
         break;
       case GSA_32_BIT_ADD :
         CPUWriteMemory(cheatsList[i].address ,
-                       cheatsList[i].value + CPUReadMemory(cheatsList[i].address) & 0xFFFFFFFF);
+                       cheatsList[i].value + (CPUReadMemory(cheatsList[i].address) & 0xFFFFFFFF));
         break;
       case GSA_8_BIT_IF_LOWER_U:
         if (!(CPUReadByte(cheatsList[i].address) < (cheatsList[i].value & 0xFF))) {

--- a/src/GBA.c
+++ b/src/GBA.c
@@ -529,7 +529,7 @@ static inline int dataTicksAccess16(u32 address) // DATA 8/16bits NON SEQ
     int waitState = value;
     if (!waitState)
       waitState = 1;
-    busPrefetchCount = ((++busPrefetchCount)<<waitState) - 1;
+    busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<waitState) - 1;
   }
 
   return value;
@@ -550,7 +550,7 @@ static inline int dataTicksAccess32(u32 address) // DATA 32bits NON SEQ
     int waitState = value;
     if (!waitState)
       waitState = 1;
-    busPrefetchCount = ((++busPrefetchCount)<<waitState) - 1;
+    busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<waitState) - 1;
   }
 
   return value;
@@ -571,7 +571,7 @@ static inline int dataTicksAccessSeq16(u32 address)// DATA 8/16bits SEQ
     int waitState = value;
     if (!waitState)
       waitState = 1;
-    busPrefetchCount = ((++busPrefetchCount)<<waitState) - 1;
+    busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<waitState) - 1;
   }
 
   return value;
@@ -592,7 +592,7 @@ static inline int dataTicksAccessSeq32(u32 address)// DATA 32bits SEQ
     int waitState = value;
     if (!waitState)
       waitState = 1;
-    busPrefetchCount = ((++busPrefetchCount)<<waitState) - 1;
+    busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<waitState) - 1;
   }
 
   return value;

--- a/src/Sound.c
+++ b/src/Sound.c
@@ -534,7 +534,7 @@ void soundEvent8(u32 address, u8 data)
   case 0x9d:
   case 0x9e:
   case 0x9f:
-    sound3WaveRam[(sound3Bank*0x10)^0x10+(address&15)] = data;
+    sound3WaveRam[((sound3Bank*0x10)^(0x10))+(address&15)] = data;
     break;
   }
 }
@@ -593,7 +593,7 @@ void soundEvent16(u32 address, u16 data)
   case 0x9a:
   case 0x9c:
   case 0x9e:
-    *((u16 *)&sound3WaveRam[(sound3Bank*0x10)^0x10+(address&14)]) = data;
+    *((u16 *)&sound3WaveRam[((sound3Bank*0x10)^(0x10))+(address&14)]) = data;
     *((u16 *)&ioMem[address]) = data;    
     break;    
   }

--- a/src/arm-new.h
+++ b/src/arm-new.h
@@ -1682,7 +1682,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
 
     }
@@ -1708,7 +1708,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2759,7 +2759,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2784,7 +2784,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2814,7 +2814,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2840,7 +2840,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2869,7 +2869,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2898,7 +2898,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2927,7 +2927,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2956,7 +2956,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
       clockTicks += codeTicksAccess32(armNextPC) + 1;
     }
     break;
@@ -2988,7 +2988,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
     }
     break;
   case 0x0f9:
@@ -3019,7 +3019,7 @@ if(cond_res) {
       else
         clockTicks += 3;
       if (!busPrefetchCount)
-        busPrefetchCount = ((++busPrefetchCount)<<clockTicks) - 1;
+        busPrefetchCount = ((busPrefetchCount + busPrefetchCount)<<clockTicks) - 1;
     }
     break;
     LOGICAL_DATA_OPCODE(OP_TST, OP_TST, 0x110);

--- a/src/arm-new.h
+++ b/src/arm-new.h
@@ -36,7 +36,6 @@
       \
       N_FLAG = (reg[dest].I & 0x80000000) ? true : false;\
       Z_FLAG = (reg[dest].I) ? false : true;\
-      C_FLAG = C_OUT;
 
 #define OP_EOR \
       reg[dest].I = reg[(opcode>>16)&15].I ^ value;
@@ -46,7 +45,6 @@
       \
       N_FLAG = (reg[dest].I & 0x80000000) ? true : false;\
       Z_FLAG = (reg[dest].I) ? false : true;\
-      C_FLAG = C_OUT;
 
 #define NEG(i) ((i) >> 31)
 #define POS(i) ((~(i)) >> 31)
@@ -178,25 +176,21 @@
 #define LOGICAL_LSL_REG \
    {\
      u32 v = reg[opcode & 0x0f].I;\
-     C_OUT = (v >> (32 - shift)) & 1 ? true : false;\
      value = v << shift;\
    }
 #define LOGICAL_LSR_REG \
    {\
      u32 v = reg[opcode & 0x0f].I;\
-     C_OUT = (v >> (shift - 1)) & 1 ? true : false;\
      value = v >> shift;\
    }
 #define LOGICAL_ASR_REG \
    {\
      u32 v = reg[opcode & 0x0f].I;\
-     C_OUT = ((s32)v >> (int)(shift - 1)) & 1 ? true : false;\
      value = (s32)v >> (int)shift;\
    }
 #define LOGICAL_ROR_REG \
    {\
      u32 v = reg[opcode & 0x0f].I;\
-     C_OUT = (v >> (shift - 1)) & 1 ? true : false;\
      value = ((v << (32 - shift)) |\
               (v >> shift));\
    }
@@ -204,14 +198,12 @@
    {\
      u32 v = reg[opcode & 0x0f].I;\
      shift = (int)C_FLAG;\
-     C_OUT = (v  & 1) ? true : false;\
      value = ((v >> 1) |\
               (shift << 31));\
    }
 #define LOGICAL_ROR_IMM \
    {\
      u32 v = opcode & 0xff;\
-     C_OUT = (v >> (shift - 1)) & 1 ? true : false;\
      value = ((v << (32 - shift)) |\
               (v >> shift));\
    }
@@ -271,13 +263,11 @@
       u32 res = reg[base].I & value;\
       N_FLAG = (res & 0x80000000) ? true : false;\
       Z_FLAG = (res) ? false : true;\
-      C_FLAG = C_OUT;
 
 #define OP_TEQ \
       u32 res = reg[base].I ^ value;\
       N_FLAG = (res & 0x80000000) ? true : false;\
       Z_FLAG = (res) ? false : true;\
-      C_FLAG = C_OUT;
 
 #define OP_ORR \
     reg[dest].I = reg[base].I | value;
@@ -286,7 +276,6 @@
     reg[dest].I = reg[base].I | value;\
     N_FLAG = (reg[dest].I & 0x80000000) ? true : false;\
     Z_FLAG = (reg[dest].I) ? false : true;\
-    C_FLAG = C_OUT;
 
 #define OP_MOV \
     reg[dest].I = value;
@@ -295,7 +284,6 @@
     reg[dest].I = value;\
     N_FLAG = (reg[dest].I & 0x80000000) ? true : false;\
     Z_FLAG = (reg[dest].I) ? false : true;\
-    C_FLAG = C_OUT;
 
 #define OP_BIC \
     reg[dest].I = reg[base].I & (~value);
@@ -304,7 +292,6 @@
     reg[dest].I = reg[base].I & (~value);\
     N_FLAG = (reg[dest].I & 0x80000000) ? true : false;\
     Z_FLAG = (reg[dest].I) ? false : true;\
-    C_FLAG = C_OUT;
 
 #define OP_MVN \
     reg[dest].I = ~value;
@@ -313,7 +300,6 @@
     reg[dest].I = ~value; \
     N_FLAG = (reg[dest].I & 0x80000000) ? true : false;\
     Z_FLAG = (reg[dest].I) ? false : true;\
-    C_FLAG = C_OUT;
 
 #define CASE_16(BASE) \
   case BASE:\
@@ -359,7 +345,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       \
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
@@ -403,7 +388,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -415,7 +399,6 @@
         LOGICAL_LSR_REG\
       } else {\
         value = 0;\
-        C_OUT = (reg[opcode & 0x0F].I & 0x80000000) ? true : false;\
       }\
       \
       if(dest == 15) {\
@@ -448,7 +431,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -461,10 +443,8 @@
       } else {\
         if(reg[opcode & 0x0F].I & 0x80000000){\
           value = 0xFFFFFFFF;\
-          C_OUT = true;\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }                   \
       }\
       \
@@ -498,7 +478,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -540,7 +519,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -551,12 +529,10 @@
       if(shift) {\
         if(shift == 32) {\
           value = 0;\
-          C_OUT = (reg[opcode & 0x0F].I & 1 ? true : false);\
         } else if(shift < 32) {\
            LOGICAL_LSL_REG\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }\
       } else {\
         value = reg[opcode & 0x0F].I;\
@@ -590,7 +566,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -601,12 +576,10 @@
       if(shift) {\
         if(shift == 32) {\
           value = 0;\
-          C_OUT = (reg[opcode & 0x0F].I & 0x80000000 ? true : false);\
         } else if(shift < 32) {\
             LOGICAL_LSR_REG\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }\
       } else {\
         value = reg[opcode & 0x0F].I;\
@@ -640,7 +613,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -657,10 +629,8 @@
       } else {\
         if(reg[opcode & 0x0F].I & 0x80000000){\
           value = 0xFFFFFFFF;\
-          C_OUT = true;\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }\
       }\
       if(dest == 15) {\
@@ -692,7 +662,6 @@
       int base = (opcode >> 16) & 0x0F;\
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -706,11 +675,9 @@
           LOGICAL_ROR_REG\
         } else {\
           value = reg[opcode & 0x0F].I;\
-          C_OUT = (value & 0x80000000 ? true : false);\
         }\
       } else {\
         value = reg[opcode & 0x0F].I;\
-        C_OUT = (value & 0x80000000 ? true : false);\
       }\
       if(dest == 15) {\
         clockTicks+=2+codeTicksAccessSeq32(armNextPC)+codeTicksAccessSeq32(armNextPC);\
@@ -755,7 +722,6 @@
       int shift = (opcode & 0xF00) >> 7;\
       int base = (opcode >> 16) & 0x0F;\
       int dest = (opcode >> 12) & 0x0F;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -799,7 +765,6 @@
       /* OP Rd,Rb,Rm LSL # */ \
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -842,7 +807,6 @@
        /* OP Rd,Rb,Rm LSR # */ \
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -854,7 +818,6 @@
         LOGICAL_LSR_REG\
       } else {\
         value = 0;\
-        C_OUT = (reg[opcode & 0x0F].I & 0x80000000) ? true : false;\
       }\
       \
       if(dest == 15) {\
@@ -886,7 +849,6 @@
        /* OP Rd,Rb,Rm ASR # */\
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -899,10 +861,8 @@
       } else {\
         if(reg[opcode & 0x0F].I & 0x80000000){\
           value = 0xFFFFFFFF;\
-          C_OUT = true;\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }                   \
       }\
       \
@@ -935,7 +895,6 @@
        /* OP Rd,Rb,Rm ROR # */\
       int shift = (opcode >> 7) & 0x1F;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -976,7 +935,6 @@
        /* OP Rd,Rb,Rm LSL Rs */\
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -987,12 +945,10 @@
       if(shift) {\
         if(shift == 32) {\
           value = 0;\
-          C_OUT = (reg[opcode & 0x0F].I & 1 ? true : false);\
         } else if(shift < 32) {\
            LOGICAL_LSL_REG\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }\
       } else {\
         value = reg[opcode & 0x0F].I;\
@@ -1025,7 +981,6 @@
        /* OP Rd,Rb,Rm LSR Rs */ \
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -1036,12 +991,10 @@
       if(shift) {\
         if(shift == 32) {\
           value = 0;\
-          C_OUT = (reg[opcode & 0x0F].I & 0x80000000 ? true : false);\
         } else if(shift < 32) {\
             LOGICAL_LSR_REG\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }\
       } else {\
         value = reg[opcode & 0x0F].I;\
@@ -1074,7 +1027,6 @@
        /* OP Rd,Rb,Rm ASR Rs */ \
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -1091,10 +1043,8 @@
       } else {\
         if(reg[opcode & 0x0F].I & 0x80000000){\
           value = 0xFFFFFFFF;\
-          C_OUT = true;\
         } else {\
           value = 0;\
-          C_OUT = false;\
         }\
       }\
       if(dest == 15) {\
@@ -1125,7 +1075,6 @@
        /* OP Rd,Rb,Rm ROR Rs */\
       int shift = reg[(opcode >> 8)&15].B.B0;\
       int dest = (opcode>>12) & 15;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\
@@ -1139,11 +1088,9 @@
           LOGICAL_ROR_REG\
         } else {\
           value = reg[opcode & 0x0F].I;\
-          C_OUT = (value & 0x80000000 ? true : false);\
         }\
       } else {\
         value = reg[opcode & 0x0F].I;\
-        C_OUT = (value & 0x80000000 ? true : false);\
       }\
       if(dest == 15) {\
         clockTicks+=2+codeTicksAccessSeq32(armNextPC)+codeTicksAccessSeq32(armNextPC);\
@@ -1187,7 +1134,6 @@
     {\
       int shift = (opcode & 0xF00) >> 7;\
       int dest = (opcode >> 12) & 0x0F;\
-      bool C_OUT = C_FLAG;\
       u32 value;\
       if ((dest == 15)||((opcode & 0x02000010)==0x10))\
       {\

--- a/src/bios.c
+++ b/src/bios.c
@@ -387,7 +387,7 @@ void BIOS_Diff8bitUnFilterWram()
   source += 4;
 
   if(((source & 0xe000000) == 0) ||
-     ((source + ((header >> 8) & 0x1fffff) & 0xe000000) == 0))
+     ((source + (((header >> 8) & 0x1fffff) & 0xe000000)) == 0))
     return;  
 
   int len = header >> 8;

--- a/src/elf.c
+++ b/src/elf.c
@@ -1075,9 +1075,6 @@ void elfParseCFA(u8 *top)
     data += 4;
     
     if(id == 0xffffffff) {
-      // skip version
-      *data++;
-
       ELFcie *cie = (ELFcie *)calloc(1, sizeof(ELFcie));
 
       cie->next = cies;

--- a/src/elf.c
+++ b/src/elf.c
@@ -135,7 +135,6 @@
 #define DW_LNS_advance_pc       0x02
 #define DW_LNS_advance_line     0x03
 #define DW_LNS_set_file         0x04
-#define DW_LNS_set_column       0x05
 #define DW_LNS_negate_stmt      0x06
 #define DW_LNS_set_basic_block  0x07
 #define DW_LNS_const_add_pc     0x08
@@ -1226,9 +1225,7 @@ void elfParseLineInfo(CompileUnit *unit, u8 *top)
     u32 address = 0;
     int file = 1;
     int line = 1;
-    int col = 0;
     int isStmt = defaultIsStmt;
-    int basicBlock = 0;
     int endSeq = 0;
 
     while(!endSeq) {
@@ -1255,7 +1252,6 @@ void elfParseLineInfo(CompileUnit *unit, u8 *top)
       case DW_LNS_copy:
         //      fprintf(stderr, "Address %08x line %d (%d)\n", address, line, file);
         elfAddLine(l, address, file, line, &max);
-        basicBlock = 0;
         break;
       case DW_LNS_advance_pc:
         address += minInstrSize * elfReadLEB128(data, &bytes);
@@ -1269,15 +1265,8 @@ void elfParseLineInfo(CompileUnit *unit, u8 *top)
         file = elfReadLEB128(data, &bytes);
         data += bytes;
         break;
-      case DW_LNS_set_column:
-        col = elfReadLEB128(data, &bytes);
-        data += bytes;
-        break;
       case DW_LNS_negate_stmt:
         isStmt = !isStmt;
-        break;
-      case DW_LNS_set_basic_block:
-        basicBlock = 1;
         break;
       case DW_LNS_const_add_pc:
         address += (minInstrSize *((255 - opcodeBase)/lineRange));
@@ -1292,7 +1281,6 @@ void elfParseLineInfo(CompileUnit *unit, u8 *top)
         line += lineBase + (op % lineRange);
         elfAddLine(l, address, file, line, &max);        
         //        fprintf(stderr, "Address %08x line %d (%d)\n", address, line,file);
-        basicBlock = 1;
         break;
       }
     }
@@ -2009,7 +1997,6 @@ u8 *elfParseBlock(u8 *data, ELFAbbrev *abbrev, CompileUnit *unit,
 {
   int bytes;
   u32 start = func->lowPC;
-  u32 end = func->highPC;
   
   for(int i = 0; i < abbrev->numAttrs; i++) {
     ELFAttr *attr = &abbrev->attrs[i];
@@ -2019,9 +2006,6 @@ u8 *elfParseBlock(u8 *data, ELFAbbrev *abbrev, CompileUnit *unit,
       break;
     case DW_AT_low_pc:
       start = attr->value;
-      break;
-    case DW_AT_high_pc:
-      end = attr->value;
       break;
     case DW_AT_ranges: // ignore for now
       break;
@@ -2177,7 +2161,6 @@ u8 *elfParseFunction(u8 *data, ELFAbbrev *abbrev, CompileUnit *unit,
   *f = func;
    
   int bytes;
-  bool mangled = false;
   bool declaration = false;
   for(int i = 0; i < abbrev->numAttrs; i++) {
     ELFAttr *attr = &abbrev->attrs[i];
@@ -2191,7 +2174,6 @@ u8 *elfParseFunction(u8 *data, ELFAbbrev *abbrev, CompileUnit *unit,
       break;
     case DW_AT_MIPS_linkage_name:
       func->name = attr->string;
-      mangled = true;
       break;
     case DW_AT_low_pc:
       func->lowPC = attr->value;

--- a/src/gb/GB.c
+++ b/src/gb/GB.c
@@ -1610,13 +1610,13 @@ u8 gbReadOpcode(register u16 address)
   if(address < 0xa000)
   {
     // A lot of 'ugly' checks... But only way to emulate this particular behaviour...
-    if (((gbHardware & 0xa) && ((gbLcdModeDelayed !=3) || ((register_LY == 0) &&
-        (gbScreenOn==false) && (register_LCDC & 0x80)) &&
-        (gbLcdLYIncrementTicksDelayed ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS)))) || 
+    if ((((gbHardware & 0xa) && ((gbLcdModeDelayed !=3) || ((register_LY == 0) &&
+        (gbScreenOn==false) && (register_LCDC & 0x80))) &&
+        ((gbLcdLYIncrementTicksDelayed ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS)))) || 
         ((gbHardware & 0x5) && (gbLcdModeDelayed !=3) &&
         ((gbLcdMode !=3) ||   ((register_LY == 0) && ((gbScreenOn==false) &&
         (register_LCDC & 0x80)) &&
-        (gbLcdLYIncrementTicks ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS))))))
+        (gbLcdLYIncrementTicks ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS)))))))
       return gbMemoryMap[address>>12][address&0x0fff];
     return 0xff;
   }
@@ -1661,7 +1661,7 @@ u8 gbReadOpcode(register u16 address)
       case 0x41:
       // This is a GB/C only bug (ie. not GBA/SP).
       if ((gbHardware & 7) && (gbLcdMode == 2) && (gbLcdModeDelayed == 1) && (!gbSpeed))
-        return (0x80 | gbMemory[0xff41] & 0xFC);
+        return ((0x80 | gbMemory[0xff41]) & 0xFC);
       else
         return (0x80 | gbMemory[0xff41]);
       case 0x42:
@@ -1760,13 +1760,13 @@ u8 gbReadMemory(register u16 address)
   if(address < 0xa000)
   {
     // A lot of 'ugly' checks... But only way to emulate this particular behaviour...
-    if (((gbHardware & 0xa) && ((gbLcdModeDelayed !=3) || ((register_LY == 0) &&
-        (gbScreenOn==false) && (register_LCDC & 0x80)) &&
-        (gbLcdLYIncrementTicksDelayed ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS)))) || 
+    if ((((gbHardware & 0xa) && ((gbLcdModeDelayed !=3) || ((register_LY == 0) &&
+        (gbScreenOn==false) && (register_LCDC & 0x80))) &&
+        ((gbLcdLYIncrementTicksDelayed ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS)))) || 
         ((gbHardware & 0x5) && (gbLcdModeDelayed !=3) &&
         ((gbLcdMode !=3) ||   ((register_LY == 0) && ((gbScreenOn==false) &&
         (register_LCDC & 0x80)) &&
-        (gbLcdLYIncrementTicks ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS))))))
+        (gbLcdLYIncrementTicks ==(GBLY_INCREMENT_CLOCK_TICKS-GBLCD_MODE_2_CLOCK_TICKS)))))))
       return gbMemoryMap[address>>12][address&0x0fff];
     return 0xff;
   }
@@ -1921,7 +1921,7 @@ u8 gbReadMemory(register u16 address)
     case 0x41:
       // This is a GB/C only bug (ie. not GBA/SP).
       if ((gbHardware & 7) && (gbLcdMode == 2) && (gbLcdModeDelayed == 1) && (!gbSpeed))
-        return (0x80 | gbMemory[0xff41] & 0xFC);
+        return ((0x80 | gbMemory[0xff41]) & 0xFC);
       else
         return (0x80 | gbMemory[0xff41]);
     case 0x42:
@@ -1987,8 +1987,8 @@ u8 gbReadMemory(register u16 address)
   // OAM not accessible during mode 2 & 3.
   if(((address >= 0xfe00) && (address<0xfea0)) &&
     (((gbLcdMode | gbLcdModeDelayed) &2) &&
-    (!(gbSpeed && (gbHardware & 0x2) && !(gbLcdModeDelayed & 2) && (gbLcdMode == 2))) ||
-      (gbSpeed && (gbHardware & 0x2) && (gbLcdModeDelayed == 0) && (gbLcdTicksDelayed == (GBLCD_MODE_0_CLOCK_TICKS-gbSpritesTicks[299])))))
+    ((!(gbSpeed && (gbHardware & 0x2) && !(gbLcdModeDelayed & 2) && (gbLcdMode == 2))) ||
+      (gbSpeed && (gbHardware & 0x2) && (gbLcdModeDelayed == 0) && (gbLcdTicksDelayed == (GBLCD_MODE_0_CLOCK_TICKS-gbSpritesTicks[299]))))))
   return 0xff;
 
   if ((address >= 0xfea0) && (address < 0xff00))

--- a/src/gb/GB.c
+++ b/src/gb/GB.c
@@ -2236,10 +2236,10 @@ void gbReset()
       
   // clean LineBuffer
   if (gbLineBuffer != NULL)
-    memset(gbLineBuffer, 0, sizeof(gbLineBuffer));
+    memset(gbLineBuffer, 0, sizeof(*gbLineBuffer));
   // clean Pix
   if (pix != NULL)
-    memset(pix, 0, sizeof(pix));
+    memset(pix, 0, sizeof(*pix));
   // clean Vram
   if (gbVram != NULL)
     memset(gbVram, 0, 0x4000);
@@ -3398,8 +3398,6 @@ bool gbReadGSASnapshot(const char *fileName)
     return false;
   }
   fseek(file, 0x13, SEEK_SET);
-  size_t read = 0;
-  int toRead = 0;
   switch(gbRomType) {
   case 0x03:
   case 0x0f:
@@ -3407,15 +3405,7 @@ bool gbReadGSASnapshot(const char *fileName)
   case 0x13:
   case 0x1b:
   case 0x1e:
-  case 0xff:
-    read = fread(gbRam, 1, (gbRamSizeMask+1), file);
-    toRead = (gbRamSizeMask+1);
-    break;
   case 0x06:
-  case 0x22:
-    read = fread(&gbMemory[0xa000],1,256,file);
-    toRead = 256;
-    break;
   default:
     systemMessage(MSG_UNSUPPORTED_SNAPSHOT_FILE,
                   N_("Unsupported snapshot file %s"),
@@ -4774,8 +4764,6 @@ void gbEmulate(int ticksToStop)
                     tempgbWindowLine = 146;
                   }
  
-                  int wy = inUseRegister_WY;
-      
                   if(register_LY >= inUseRegister_WY) {
 
                     if (tempgbWindowLine == -1)

--- a/src/gb/gbCheats.c
+++ b/src/gb/gbCheats.c
@@ -177,11 +177,6 @@ bool gbVerifyGsCode(const char *code)
     if(!GBCHEAT_IS_HEX(code[i]))
       return false;
 
-  int address = GBCHEAT_HEX_VALUE(code[6]) << 12 |
-    GBCHEAT_HEX_VALUE(code[7]) << 8 |
-    GBCHEAT_HEX_VALUE(code[4]) << 4 |
-    GBCHEAT_HEX_VALUE(code[5]);
-
   return true;
 }
 

--- a/src/gb/gbCodes.h
+++ b/src/gb/gbCodes.h
@@ -315,7 +315,7 @@
    break;
  case 0x37:
    // SCF
-   AF.B.B0 = AF.B.B0 & Z_FLAG | C_FLAG;
+   AF.B.B0 = AF.B.B0 & (Z_FLAG | C_FLAG);
    break;   
 case 0x38:
   // JR C,NN

--- a/src/gb/gbCodes.h
+++ b/src/gb/gbCodes.h
@@ -315,7 +315,7 @@
    break;
  case 0x37:
    // SCF
-   AF.B.B0 = AF.B.B0 & (Z_FLAG | C_FLAG);
+   AF.B.B0 = (AF.B.B0 & Z_FLAG) | C_FLAG;
    break;   
 case 0x38:
   // JR C,NN

--- a/src/gb/gbGfx.c
+++ b/src/gb/gbGfx.c
@@ -583,10 +583,12 @@ void gbDrawSprites(bool draw)
           {
             for (int j = x-8; j<300; j++)
               if (j>=0)
+                {
                 if (gbSpeed)
                   gbSpritesTicks[j] += 5;
                 else
                   gbSpritesTicks[j] += 2+(count&1);
+                }
 
           }
           count++;

--- a/src/gb/gbMemory.c
+++ b/src/gb/gbMemory.c
@@ -1303,9 +1303,6 @@ void mapperTAMA5RAM(u16 address, u8 value)
         gbDataTAMA5.mapperCommands[gbDataTAMA5.mapperCommandNumber] = value;
         gbMemoryMap[0xa][0] = value;
 
-        int test = gbDataTAMA5.mapperCommands[gbDataTAMA5.mapperCommandNumber & 0x0e] |
-                                    (gbDataTAMA5.mapperCommands[(gbDataTAMA5.mapperCommandNumber & 0x0e) +1]<<4);
-
         if ((gbDataTAMA5.mapperCommandNumber & 0xe) == 0) // Read Command !!!
         {
           gbDataTAMA5.mapperROMBank = gbDataTAMA5.mapperCommands[0] |
@@ -1658,8 +1655,6 @@ void memoryUpdateMapMMM01()
 // GameGenie ROM write registers
 void mapperGGROM(u16 address, u8 value)
 {
-  int tmpAddress = 0;
-
   switch(address & 0x6000) {
   case 0x0000: // RAM enable register
     break;

--- a/src/gb/gbMemory.c
+++ b/src/gb/gbMemory.c
@@ -1181,30 +1181,32 @@ void memoryUpdateMapHuC3()
 
 // TAMA5 (for Tamagotchi 3 (gb)).
 // Very basic (and ugly :p) support, only rom bank switching is actually working...
-mapperTAMA5 gbDataTAMA5 = {
+mapperTAMA5 gbDataTAMA5 = { 
   1, // RAM enable
   1, // ROM bank
   0, // RAM bank
   0, // RAM address
   0, // RAM Byte select
   0, // mapper command number
-  0, // mapper last command;
-  0, // commands 0x0
-  0, // commands 0x1
-  0, // commands 0x2
-  0, // commands 0x3
-  0, // commands 0x4
-  0, // commands 0x5
-  0, // commands 0x6
-  0, // commands 0x7
-  0, // commands 0x8
-  0, // commands 0x9
-  0, // commands 0xa
-  0, // commands 0xb
-  0, // commands 0xc
-  0, // commands 0xd
-  0, // commands 0xe
-  0, // commands 0xf
+  0, // mapper last command
+  {
+    0, // commands 0x0
+    0, // commands 0x1
+    0, // commands 0x2
+    0, // commands 0x3
+    0, // commands 0x4
+    0, // commands 0x5
+    0, // commands 0x6
+    0, // commands 0x7
+    0, // commands 0x8
+    0, // commands 0x9
+    0, // commands 0xa
+    0, // commands 0xb
+    0, // commands 0xc
+    0, // commands 0xd
+    0, // commands 0xe
+    0  // commands 0xf
+  },
   0, // register
   0, // timer clock latch
   0, // timer clock register
@@ -1333,8 +1335,8 @@ void mapperTAMA5RAM(u16 address, u8 value)
           // Write Commands !!!
           if (gbDataTAMA5.mapperCommands[0x0f] && (gbDataTAMA5.mapperCommandNumber == 7))
           {
-            int data = gbDataTAMA5.mapperCommands[0x04] & 0x0f |
-                      (gbDataTAMA5.mapperCommands[0x05] <<4);
+            int data = gbDataTAMA5.mapperCommands[0x04] & (0x0f |
+                      (gbDataTAMA5.mapperCommands[0x05]) <<4);
 
             // Not sure when the write command should reset...
             // but it doesn't seem to matter.
@@ -1467,7 +1469,7 @@ void mapperTAMA5RAM(u16 address, u8 value)
           for (int i = 0; i<0x10; i++)
             for (int j = 0; j<0x10; j++)
               if (!(j&2))
-                gbTAMA5ram[(i*0x10)+j | 2] = gbTAMA5ram[(i*0x10)+j];
+                gbTAMA5ram[((i*0x10)+j) | 2] = gbTAMA5ram[(i*0x10)+j];
           // Enable this to see the content of the flashrom in 0xe000
           /*for (int k = 0; k<0x100; k++)
             gbMemoryMap[0xe][k] = gbTAMA5ram[k];*/

--- a/src/gb/gbSound.c
+++ b/src/gb/gbSound.c
@@ -343,7 +343,7 @@ void gbSoundEvent(register u16 address, register int data)
       sound4On = 0;
       gbMemory[address] &= 0xf0;
     }
-    gbMemory[address] = data & 0x80 | 0x70 | (gbMemory[address] & 0xf);
+    gbMemory[address] = data & (0x80 | 0x70 | (gbMemory[address] & 0xf));
     break;
   }
 

--- a/src/sdl/SDL.c
+++ b/src/sdl/SDL.c
@@ -1428,7 +1428,7 @@ void sdlPollEvents()
               soundPause();
           }
           
-          memset(delta,255,sizeof(delta));
+          memset(delta,255,sizeof(*delta));
         }
       }
       break;
@@ -2419,12 +2419,8 @@ void systemDrawScreen()
     u8 *src = pix;
     u8 *dest = (u8*)surface->pixels;
     int i;
-    u32 *stretcher = (u32 *)sdlStretcher;
     if(systemColorDepth == 16)
       src += srcPitch;
-    int option = sizeOption;
-    if(yuv)
-      option = 0;
     switch(sizeOption) {
     case 0:
       for(i = 0; i < srcHeight; i++) {

--- a/src/sdl/debugger.c
+++ b/src/sdl/debugger.c
@@ -750,6 +750,19 @@ static void debuggerDebug(int n, char **args)
     debuggerUsage("trace");      
 }
 
+#ifdef DEV_VERSION
+static void debuggerVerbose(int n, char **args)
+{
+  if(n == 2) {
+    int v = 0;
+    sscanf(args[1], "%d", &v);
+    systemVerbose = v;
+    printf("Verbose level set to %d\n", systemVerbose);
+  } else
+    debuggerUsage("verbose");    
+}
+#endif
+
 static void debuggerWhere(int n, char **args)
 {
   void elfPrintCallChain(u32);

--- a/src/sdl/debugger.c
+++ b/src/sdl/debugger.c
@@ -121,7 +121,6 @@ static void debuggerPrint(int, char **);
 static void debuggerQuit(int, char **);
 static void debuggerSetRadix(int, char **);
 static void debuggerSymbols(int, char **);
-static void debuggerVerbose(int, char **);
 static void debuggerWhere(int, char **);
 
 static void debuggerReadState(int, char **);
@@ -749,17 +748,6 @@ static void debuggerDebug(int n, char **args)
     printf("Debug level set to %d\n", systemDebug);
   } else
     debuggerUsage("trace");      
-}
-
-static void debuggerVerbose(int n, char **args)
-{
-  if(n == 2) {
-    int v = 0;
-    sscanf(args[1], "%d", &v);
-    systemVerbose = v;
-    printf("Verbose level set to %d\n", systemVerbose);
-  } else
-    debuggerUsage("verbose");    
 }
 
 static void debuggerWhere(int n, char **args)
@@ -2245,7 +2233,7 @@ static void debuggerCondValidate(int n,char **args,int start)
   char *address=args[start];
   char *op=args[start+1];
   char *value=args[start+2];
-  char *tsize,*taddress,*tvalue;
+  char *taddress,*tvalue;
 
   int rel=0;
   
@@ -2262,20 +2250,6 @@ static void debuggerCondValidate(int n,char **args,int start)
       return;
     }
     
-    switch(size) {
-    case 'b':
-      debuggerBreakpointList[i].cond_size=1;
-      tsize="byte";
-      break;
-    case 'h':
-      debuggerBreakpointList[i].cond_size=2;
-      tsize="halfword";
-      break;
-    case 'w':
-      debuggerBreakpointList[i].cond_size=4;
-      tsize="word";
-      break;
-    }
   }
 
   switch(toupper(address[0])) {

--- a/src/unzip.c
+++ b/src/unzip.c
@@ -534,12 +534,12 @@ local int unzlocal_GetCurrentFileInfoInternal (unzFile file,
 
         /* we check the magic */
         if (err==UNZ_OK)
-          {
+        {
                 if (unzlocal_getLong(s->file,&uMagic) != UNZ_OK)
                         err=UNZ_ERRNO;
                 else if (uMagic!=0x02014b50)
                         err=UNZ_BADZIPFILE;
-          }
+        }
 
         if (unzlocal_getShort(s->file,&file_info.version) != UNZ_OK)
                 err=UNZ_ERRNO;
@@ -616,12 +616,12 @@ local int unzlocal_GetCurrentFileInfoInternal (unzFile file,
                         uSizeRead = extraFieldBufferSize;
 
                 if (lSeek!=0)
-                  {
+                {
                         if (fseek(s->file,lSeek,SEEK_CUR)==0)
                                 lSeek=0;
                         else
                                 err=UNZ_ERRNO;
-                  }
+                }
                 if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
                         if (fread(extraField,(uInt)uSizeRead,1,s->file)!=1)
                                 err=UNZ_ERRNO;
@@ -643,12 +643,12 @@ local int unzlocal_GetCurrentFileInfoInternal (unzFile file,
                         uSizeRead = commentBufferSize;
 
                 if (lSeek!=0)
-                  {
+                {
                         if (fseek(s->file,lSeek,SEEK_CUR)==0)
                                 lSeek=0;
                         else
                                 err=UNZ_ERRNO;
-                  }
+                }
                 if ((file_info.size_file_comment>0) && (commentBufferSize>0))
                         if (fread(szComment,(uInt)uSizeRead,1,s->file)!=1)
                                 err=UNZ_ERRNO;
@@ -818,12 +818,12 @@ local int unzlocal_CheckCurrentFileCoherencyHeader (unz_s *s,
 
 
         if (err==UNZ_OK)
-          {
+        {
                 if (unzlocal_getLong(s->file,&uMagic) != UNZ_OK)
                         err=UNZ_ERRNO;
                 else if (uMagic!=0x04034b50)
                         err=UNZ_BADZIPFILE;
-          }
+        }
 
         if (unzlocal_getShort(s->file,&uData) != UNZ_OK)
                 err=UNZ_ERRNO;

--- a/src/unzip.c
+++ b/src/unzip.c
@@ -534,10 +534,12 @@ local int unzlocal_GetCurrentFileInfoInternal (unzFile file,
 
         /* we check the magic */
         if (err==UNZ_OK)
+          {
                 if (unzlocal_getLong(s->file,&uMagic) != UNZ_OK)
                         err=UNZ_ERRNO;
                 else if (uMagic!=0x02014b50)
                         err=UNZ_BADZIPFILE;
+          }
 
         if (unzlocal_getShort(s->file,&file_info.version) != UNZ_OK)
                 err=UNZ_ERRNO;
@@ -614,10 +616,12 @@ local int unzlocal_GetCurrentFileInfoInternal (unzFile file,
                         uSizeRead = extraFieldBufferSize;
 
                 if (lSeek!=0)
+                  {
                         if (fseek(s->file,lSeek,SEEK_CUR)==0)
                                 lSeek=0;
                         else
                                 err=UNZ_ERRNO;
+                  }
                 if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
                         if (fread(extraField,(uInt)uSizeRead,1,s->file)!=1)
                                 err=UNZ_ERRNO;
@@ -639,10 +643,12 @@ local int unzlocal_GetCurrentFileInfoInternal (unzFile file,
                         uSizeRead = commentBufferSize;
 
                 if (lSeek!=0)
+                  {
                         if (fseek(s->file,lSeek,SEEK_CUR)==0)
                                 lSeek=0;
                         else
                                 err=UNZ_ERRNO;
+                  }
                 if ((file_info.size_file_comment>0) && (commentBufferSize>0))
                         if (fread(szComment,(uInt)uSizeRead,1,s->file)!=1)
                                 err=UNZ_ERRNO;
@@ -812,10 +818,12 @@ local int unzlocal_CheckCurrentFileCoherencyHeader (unz_s *s,
 
 
         if (err==UNZ_OK)
+          {
                 if (unzlocal_getLong(s->file,&uMagic) != UNZ_OK)
                         err=UNZ_ERRNO;
                 else if (uMagic!=0x04034b50)
                         err=UNZ_BADZIPFILE;
+          }
 
         if (unzlocal_getShort(s->file,&uData) != UNZ_OK)
                 err=UNZ_ERRNO;


### PR DESCRIPTION
This silences several warnings with `CFLAGS="-Wall" make`. However there still several warnings when optimizing with `-Og`, `-Os`, `-O2` and `-O3` which could be resolved too.

As well as these two associated with a file generated during the build leaving me unsure where the source of the warning originated.

```
cc -std=gnu99 -DSDL -DBKPT_SUPPORT -DSYSCONFDIR=\"/usr/local/etc\" -Wall  -c -o src/gen/expr.o src/gen/expr.c
cc -std=gnu99 -DSDL -DBKPT_SUPPORT -DSYSCONFDIR=\"/usr/local/etc\" -Wall  -c -o src/gen/expr-lex.o src/gen/expr-lex.c
src/gen/expr-lex.c:1176:17: warning: ‘yyunput’ defined but not used [-Wunused-function]
     static void yyunput (int c, char * yy_bp )
                 ^
src/gen/expr-lex.c:1219:16: warning: ‘input’ defined but not used [-Wunused-function]
     static int input  (void)
```

Here is a build log with the warnings.
http://pastebin.com/eJzi7LLv
