### PR TITLE
Makefile: Clean TestEmu.o too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ VBAOBJS=$(VBASRCS:.c=.o)
 TESTEMUSRCS=$(MAINSRCS) $(GBSRCS) $(SDLSRCS) src/sdl/TestEmu.c
 TESTEMUOBJS=$(TESTEMUSRCS:.c=.o)
 
+SRCS=$(MAINSRCS) $(GBSRCS) $(SDLSRCS) src/sdl/SDL.c src/sdl/TestEmu.c
+OBJS=$(SRCS:.c=.o)
+
 LEX=flex
 
 -include config.mak
@@ -41,7 +44,7 @@ TestEmu: $(TESTEMUOBJS)
 clean:
 	rm -f $(GENSRCS)
 	rm -f $(PROGS)
-	rm -f $(VBAOBJS)
+	rm -f $(OBJS)
 
 %.o: %.c
 	$(C99) $(CPPFLAGS) $(CFLAGS) $(INC) -c -o $@ $<


### PR DESCRIPTION
`TestEmu.o` is never removed along with the other object files with `make clean`. Since changing `SDLSRCS` is problematic this just cleans up `$(OBJS)` instead of `$(VBAOBJS)` which is still used for the `VisualBoyAdvance` build target.
